### PR TITLE
Omstrukturering av veilederen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # veileder-beskrivelse-av-datasett
 For forvaltning av "Veileder for beskrivelse av datasett"
 
-Gjeldende versjon blir publisert til: https://doc.difi.no/data/veileder-for-beskrivelse-av-datasett/
+Gjeldende versjon blir publisert til: https://data.norge.no/guide/veileder-beskrivelse-av-datasett/
 
 Redaktørens utkast blir publisert til: https://informasjonsforvaltning.github.io/veileder-beskrivelse-av-datasett/
 

--- a/docs/Datakatalog.adoc
+++ b/docs/Datakatalog.adoc
@@ -1,4 +1,6 @@
-== Datakatalog
+== Beskrivelse av en datakatalog [[datakatalog]]
+
+WARNING: [red yellow-background]#_NB! hele kapittelet er under oppdatering_#
 
 === Hva er en datakatalog?
 

--- a/docs/Datasett.adoc
+++ b/docs/Datasett.adoc
@@ -1,5 +1,7 @@
 
-== Datasett
+== Beskrivelse av et datasett [[datasett]]
+
+WARNING: [red yellow-background]#_NB! hele kapittelet er under oppdatering_#
 
 === Hvordan beskrive et datasett?
 

--- a/docs/Datatjeneste.adoc
+++ b/docs/Datatjeneste.adoc
@@ -1,0 +1,5 @@
+== Beskrivelse av en datatjeneste [[datatjeneste]]
+
+Nytt i DCAT-AP-NO v.2 er at standarden nå også støtter beskriveser av datatjeneste (aka API), som v.1.x av DCAT-AP-NO ikke gjorde.
+
+[red yellow-background]#_tekst kommer_#

--- a/docs/Distribusjon.adoc
+++ b/docs/Distribusjon.adoc
@@ -1,4 +1,6 @@
-== Distribusjon
+== Beskrivelse av en distribusjon [[distribusjon]]
+
+WARNING: [red yellow-background]#_NB! hele kapittelet er under oppdatering_#
 
 En distribusjon er en spesifikk måte å gjøre et datasettet tilgjengelig på. Hvert datasett kan være tilgjengelig på flere måter, for eksempel i ulike format eller fra ulike nettadresser. Eksempel på distribusjoner kan være nedlastbar CSV-fil, et API eller en RSS-strøm.
 

--- a/docs/Innledning.adoc
+++ b/docs/Innledning.adoc
@@ -2,11 +2,11 @@
 
 === Hensikt og avgrensing [[hensikt-og-avgrensing]]
 
-Denne veilederen skal bidra til bedre beskrivelser av datasettene som virksomhetene i offentlig sektor forvalter, som en del av prosessene for å skape orden i eget hus, oppnå mer gjenbruk av data mellom offentlige virksomheter  og å gjøre mer åpne offentlige data tilgjengelig for næringsliv og sivilsamfunn. Se https://data.norge.no/guide/veileder-orden-i-eget-hus/[Veileder for orden i eget hus] for hvordan din virksomhet skaper orden i eget hus, bl.a. hvordan kartlegge hvilke data som skal beskrives.
+Denne veilederen skal bidra til bedre beskrivelser av datasettene som forvaltes av en virksomhet. For offentlige virksomheter kan dette være en del av prosessene for å skape orden i eget hus, oppnå mer gjenbruk av data mellom offentlige virksomheter  og å gjøre mer åpne offentlige data tilgjengelig for næringsliv og sivilsamfunn. Se https://data.norge.no/guide/veileder-orden-i-eget-hus/[Veileder for orden i eget hus] for hvordan din virksomhet skaper orden i eget hus, bl.a. hvordan kartlegge hvilke data som skal beskrives.
 
 Denne veilederen tar utgangspunktet i at din virksomhet har kartlagt hvilke data som skal beskrives. Veilederen skal gi en hjelp i å beskrive data i henhold til forvaltningsstandarden https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO], slik at beskrivelsene kan utnyttes godt av andre.
 
-Det er ikke et mål for denne veilederen å beskrive alle felter i DCAT-AP-NO, heller ikke teknisk og normativt. For normative beskrivelser alle feltene i DCAT-AP-NO, se https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO] og https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl[valideringsreglene (shacl)].
+Det er ikke et mål for denne veilederen å beskrive alle felter i DCAT-AP-NO, heller ikke teknisk og normativt. For normative beskrivelser av alle feltene i DCAT-AP-NO, se https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO] og https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl[valideringsreglene (shacl)].
 
 Denne veilederen er ikke en direkte veiledning for bruk av https://data.norge.no/publishing[registreringsverktøyet i Fellesdatakatalogen].
 

--- a/docs/Innledning.adoc
+++ b/docs/Innledning.adoc
@@ -1,49 +1,33 @@
+== Om denne veilederen [[om-denne-veilederen]]
 
-NOTE: For normative beskrivelser av feltene som er omtalt i dette dokumentet, se DCAT-AP-NO: https://doc.difi.no/data/dcat-ap-no-stotte-til-teknisk-implementering/[Støtte til teknisk implementering av dcat-ap-no]
+=== Hensikt og avgrensing [[hensikt-og-avgrensing]]
 
-== Innledning
+Denne veilederen skal bidra til bedre beskrivelser av datasettene som virksomhetene i offentlig sektor forvalter, som en del av prosessene for å skape orden i eget hus, oppnå mer gjenbruk av data mellom offentlige virksomheter  og å gjøre mer åpne offentlige data tilgjengelig for næringsliv og sivilsamfunn. Se https://data.norge.no/guide/veileder-orden-i-eget-hus/[Veileder for orden i eget hus] for hvordan din virksomhet skaper orden i eget hus, bl.a. hvordan kartlegge hvilke data som skal beskrives.
 
-=== Bakgrunn
+Denne veilederen tar utgangspunktet i at din virksomhet har kartlagt hvilke data som skal beskrives. Veilederen skal gi en hjelp i å beskrive data i henhold til forvaltningsstandarden https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO], slik at beskrivelsene kan utnyttes godt av andre.
 
-Digital Agenda og Digitaliseringsrundskrivet viser til målet om at brukeren (privatperson, offentlig og privat virksomhet og frivilligheten) ikke skal trenge å avgi informasjon som han allerede har avgitt. I https://lovdata.no/dokument/NL/lov/1997-06-06-35#shareModal[Lov om Oppgaveregisteret] § 5 stilles det krav til statlige virksomheter at informasjon fra næringslivet er samordnet slik at man ikke etterspør samme informasjon flere ganger. Det langsiktige målet er at gjenbruk er hovedregel.
+Det er ikke et mål for denne veilederen å beskrive alle felter i DCAT-AP-NO, heller ikke teknisk og normativt. For normative beskrivelser alle feltene i DCAT-AP-NO, se https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO] og https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl[valideringsreglene (shacl)].
 
-Den enkelte offentlige virksomhet har etter https://www.regjeringen.no/no/dokumenter/digitaliseringsrundskrivet/id2569983/[Digitaliseringsrundskrivet] (spesielt punkt 1.3) krav til å holde en oversikt over hvilke data de forvalter. Videre legger Regjeringens https://www.regjeringen.no/id2536870/[Retningslinjer ved tilgjengeliggjøring av offentlige data] opp til at offentlige data skal dokumenteres og synliggjøres slik at de er enkle å oppdage, vurdere og eventuelt ta i bruk til nye formål.
+Denne veilederen er ikke en direkte veiledning for bruk av https://data.norge.no/publishing[registreringsverktøyet i Fellesdatakatalogen].
 
-Difi forvalter et https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/nasjonal-arkitektur/informasjonsforvaltning[felles offentlig rammeverk for informasjonsforvaltning] som inneholder veiledere, spesifikasjoner og standarder som er  relevante for informasjonsforvaltning i offentlig sektor. En https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/nasjonal-arkitektur/informasjonsforvaltning/veileder-orden-i-eget-hus[Veileder for orden i eget hus] er laget for å støtte arbeid med å etablere en praksis for dette i egen virksomhet og en https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/nasjonal-arkitektur/informasjonsforvaltning/faglig-arena-informasjonsforvaltning[faglig arena for informasjonsforvaltning] etablert av Difi for å gi erfaringsutveksling mellom de offentlige virksomhetene.
+=== Målgruppe [[målgruppe]]
 
-Offentlige virksomheter forvalter store mengder opplysninger fordelt på mange registre. For at offentlige virksomheter skal utnytte informasjon fra andre ved utvikling av digitale brukerrettede tjenester, trenger de å vite hvilken informasjon som finnes og kan gjenbrukes. De behøver å kjenne til hvilke datasett som finnes, og evaluere om de er riktige til sitt formål. Til dette trengs egne oversikter å eksponeres utenfor virksomheten. Private virksomheter trenger en oversikt for å kunne finne, forstå og nyttiggjøre seg av åpne data til transparens, innovasjon og næringsutvikling, og få tilgang til opplysninger som kan bedre brukers prosess i private løsninger (myData) der deling skjer med brukers samtykke.
+Målgruppen for denne veilederen er primært deg som skal beskrive datasett, datatjenester og datakataloger i din virksomhet i henhold til https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO].
 
-En felles oversikt etableres med Felles datakatalog. DCAT-AP v1.1 er den gjeldende europeiske spesifikasjonen for beskrivelser av datasett og datakataloger. Formålet er å gjøre det enklere å søke etter åpne datasett på tvers av dataportaler i EUs medlemsstater. En norsk versjon kalt https://doc.difi.no/dcat-ap-no/[DCAT-AP-NO] 1.1 er basert på den europeiske. Den norske standarden inneholder utvidelser som er nyttig for også å beskrive datasett som ikke er åpne.
+Sekundært kan også veilederen brukes av deg som skal utvikle/tilpasse verktøystøtte i virksomhetene for beskrivelser av datasett/datatjenester/datakataloger og/eller eksponering av slike beskrivelser i henhold til https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO].
 
-=== Veilederen
+=== Struktur [[struktur]]
 
-==== Mål og hensikt
+[red yellow-background]#_foreløpig tekst_:#
 
-Denne veilederen skal bidra til bedre beskrivelser av datasettene som virksomhetene i offentlig sektor forvalter, som en del av prosessene for å skape orden i eget hus, oppnå mer gjenbruk av data mellom offentlige virksomheter  og å gjøre mer åpne offentlige data tilgjengelig for næringsliv og sivilsamfunn. Veilederen tar ikke stilling til hvordan du skal kartlegge hvilken informasjon din virksomhet forvalter. For kartlegging av informasjon i din virksomhet, kan bl.a. Difis veileder for http://internkontroll.infosikkerhet.difi.no/[Internkontroll i praksis - informasjonssikkerhet] brukes.
+Denne veilederen beskriver hvordan du beskriver:
 
-Denne veilederen er laget for å gi en hjelp til at innholdet fra virksomhetene beskrives slik at de kan utnyttes godt av andre. Veilederen skal hjelpe de offentlige virksomhetene å beskrive sine data i henhold til forvaltningsstandarden https://doc.difi.no/dcat-ap-no/[DCAT-AP-NO].
+* et <<datasett, datasett>>
 
-==== Struktur
+* en <<distribusjon, distribusjon>>
 
-Digitaliseringsrundskrivet sier
+* en <<datatjeneste, datatjeneste>>
 
-[quote, Digitaliseringsrundskrivet 2017]
-Den enkelte virksomhet skal ha oversikt over hvilke data den håndterer,  hva dataene betyr, hva de kan brukes til, hvilke prosesser de inngår i, og hvem som kan bruke dem (informasjonsforvaltning). +
-I samsvar med viderebruksbestemmelsene i offentleglova skal virksomheten gjøre egnet informasjon tilgjengelig i maskinlesbare formater, fortrinnsvis gjennom API'er.
+* en <<datakatalog, datakatalog>>
 
-Strukturen på veilederen er bygget opp i henhold til dette. Veilederen skal bidra til å beskrive bedre bl.a.
-
- . Hvilke datasett man har?
- . Hvem forvalter datasettene?
- . Hva er opphavet til dataene?
- . Til hvilket formål er de samlet inn?
- . Hvilke tjenester kan man benytte for å få tilgang til dataene?
- . Er dataene autoritative?
-
-Vedlegg A gir normative definisjoner av feltene.
-
-==== Målgruppe
-
-Målgruppen for denne veilederen er primært deg som skal bruke DCAT-AP-NO til å beskrive datasett og datakataloger i din virksomhet.
-
-Sekundært kan også veilederen brukes av deg som skal utvikle/tilpasse verktøystøtte i virksomhetene for beskrivelser av datasett/datakataloger og/eller eksponering av slike beskrivelser i henhold til DCAT-AP-NO.
+* [red yellow-background]#_muligens et kapittel for egenskaper som inngår i flere klasser?_#

--- a/docs/Referanser.adoc
+++ b/docs/Referanser.adoc
@@ -1,8 +1,12 @@
 
 == Referanser
 
-DCAT-W3C: https://www.w3.org/TR/vocab-dcat/[Data Catalog Vocabulary (DCAT), Recommendation 16 January 2014] +
-DCAT-AP: https://joinup.ec.europa.eu/asset/dcat_application_profile/home[DCAT Application Profile for data portals in Europe, version 1.1], 2015-10-23 +
-DCAT-AP-NO: https://doc.difi.no/dcat-ap-no/[Standard for beskrivelse av datasett og datakataloger, versjon 1.1], 2016-10-11 +
-W3C-DWBP: http://www.w3.org/TR/dwbp/[Data on the Web Best Practices- Working Draft 12 January 2016]
-POD: Project Open Data Metadata Schema v1.1, February 2015
+WARNING: [red yellow-background]#_NB! hele kapittelet er under oppdatering_#
+
+DCAT: https://www.w3.org/TR/vocab-dcat/[Data Catalog Vocabulary (DCAT) - Version 2], W3C Recommendation, 2020-02-04
+
+DCAT-AP: https://joinup.ec.europa.eu/asset/dcat_application_profile/home[DCAT Application Profile for data portals in Europe], version 2.0.0+, 2019-10-03+
+
+DCAT-AP-NO: https://data.norge.no/specification/dcat-ap-no/[tandard for beskrivelse av datasett, datatjenester og datakataloger (DCAT-AP-NO)], versjon 2.0.0+, 2020-10-29+
+
+W3C-DWBP: http://www.w3.org/TR/dwbp/[Data on the Web Best Practices], W3C Recommendation, 2017-01-31

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -31,12 +31,21 @@ Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn 
 
 // Innhold her.
 include::Innledning.adoc[]
-include::Hva_er_et_datasett.adoc[]
+
+// include::Hva_er_et_datasett.adoc[]
+
 include::Datasett.adoc[]
-include::Enhet.adoc[]
-include::Kontaktpunkt.adoc[]
+
+// include::Enhet.adoc[]
+
+// include::Kontaktpunkt.adoc[]
+
 include::Distribusjon.adoc[]
+
+include::Datatjeneste.adoc[]
+
 include::Datakatalog.adoc[]
+
 include::Referanser.adoc[]
 
 


### PR DESCRIPTION
Her kommer en ny PR, hvor hovedintensjonen er omstrukturering. Bortsett fra endring av tekst i Innledning.adoc for å gjenspeile den nye strukturen, er de andre kapitlene/filene ikke oppdatert (bortsett fra å sette opp WARNING, eller å bli ekskludert fra main.adoc). 

Kan du se på dette før jeg oppdaterer innholdet i de ulike kapitlene? 