### PR TITLE
Markere v1 tydelig som utgått

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # veileder-beskrivelse-av-datasett
 
-Gjelden versjon er publisert her: https://doc.difi.no/data/veileder-for-beskrivelse-av-datasett/
+Veilederen er utgått og vil ikke bli vedlikeholdt.

--- a/docs/Innledning.adoc
+++ b/docs/Innledning.adoc
@@ -1,5 +1,5 @@
 
-NOTE: For normative beskrivelser av feltene som er omtalt i dette dokumentet, se DCAT-AP-NO: https://doc.difi.no/data/dcat-ap-no-stotte-til-teknisk-implementering/[Støtte til teknisk implementering av dcat-ap-no]
+// NOTE: For normative beskrivelser av feltene som er omtalt i dette dokumentet, se DCAT-AP-NO: https://doc.difi.no/data/dcat-ap-no-stotte-til-teknisk-implementering/[Støtte til teknisk implementering av dcat-ap-no]
 
 == Innledning
 

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -22,7 +22,7 @@ image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 // markere denne som "utgått" med fixed textbox her kodet direkte i html
 ++++
 <div style="position: fixed; top: 40%; left: 50%; transform: translateX(-50%); background-color: #ffffff; border: 1px solid black; padding: 15px; box-shadow: 15px 15px 15px red; opacity: 0.85">
-  <p> <strong>NB! Denne veilederen er utgått. Den var ment for å forklare bruken av DCAT-AP-NO v1.1. som var utgått.</a> </strong> </p>
+  <p> <strong>NB! Denne veilederen er utgått. Den var ment for å forklare bruken av DCAT-AP-NO v1.1. som var utgått.</strong> </p>
 </div>
 ++++
 

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -19,10 +19,17 @@ image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
 {description}
 
-IMPORTANT: Denne versjonen av veilederen var utarbeidet for https://data.norge.no/specification/dcat-ap-no/v1.1/[DCAT-AP-NO v.1.1] som er [yellow-background]#under utfasing#. Denne versjon av veilederen vil ikke bli oppdatert. +
-For https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO v.2.x] se den https://data.norge.no/guide/veileder-beskrivelse-av-datasett/[gjeldende versjon av veilederen].
+// IMPORTANT: Denne versjonen av veilederen var utarbeidet for https://data.norge.no/specification/dcat-ap-no/v1.1/[DCAT-AP-NO v.1.1] som er [yellow-background]#under utfasing#. Denne versjon av veilederen vil ikke bli oppdatert. +
+// For https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO v.2.x] se den https://data.norge.no/guide/veileder-beskrivelse-av-datasett/[gjeldende versjon av veilederen].
 
-include::./shared/download.adoc[]
+// include::./shared/download.adoc[]
+
+// markere denne som "utgått" med fixed textbox her kodet direkte i html
+++++
+<div style="position: fixed; top: 40%; left: 50%; transform: translateX(-50%); background-color: #ffffff; border: 1px solid black; padding: 15px; box-shadow: 15px 15px 15px red; opacity: 0.85">
+  <p> <b>NB! Denne veilederen er utgått. Den var ment for å forklare bruken av DCAT-AP-NO v1.1. som var utgått.</a> </b> </p>
+</div>
+++++
 
 toc::[]
 

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -19,15 +19,10 @@ image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
 {description}
 
-// IMPORTANT: Denne versjonen av veilederen var utarbeidet for https://data.norge.no/specification/dcat-ap-no/v1.1/[DCAT-AP-NO v.1.1] som er [yellow-background]#under utfasing#. Denne versjon av veilederen vil ikke bli oppdatert. +
-// For https://data.norge.no/specification/dcat-ap-no/[DCAT-AP-NO v.2.x] se den https://data.norge.no/guide/veileder-beskrivelse-av-datasett/[gjeldende versjon av veilederen].
-
-// include::./shared/download.adoc[]
-
 // markere denne som "utgått" med fixed textbox her kodet direkte i html
 ++++
 <div style="position: fixed; top: 40%; left: 50%; transform: translateX(-50%); background-color: #ffffff; border: 1px solid black; padding: 15px; box-shadow: 15px 15px 15px red; opacity: 0.85">
-  <p> <b>NB! Denne veilederen er utgått. Den var ment for å forklare bruken av DCAT-AP-NO v1.1. som var utgått.</a> </b> </p>
+  <p> <strong>NB! Denne veilederen er utgått. Den var ment for å forklare bruken av DCAT-AP-NO v1.1. som var utgått.</a> </strong> </p>
 </div>
 ++++
 


### PR DESCRIPTION
Markerer v1 av veilederen tydelig som utgått, ved å bruke tekstboks med fast plassering